### PR TITLE
Changes to become a Peertube rss-to-signal-bridge

### DIFF
--- a/app.py
+++ b/app.py
@@ -36,14 +36,13 @@ def send_message(body):
         log.info("Body:\n%s" % body)
     else:
         r = requests.post(SIGNAL_API_URL, headers={"Content-Type":"application/json"},
-                json={"message": body, "recipients": DESTINATIONS, "number": SOURCE})
+                json={"message": body, "text_mode": "styled", "recipients": DESTINATIONS, "number": SOURCE})
         log.info("Message sent to Signal with HTTP response code %s and content %s" % (r.status_code, r.content))
 
-def format_message(template, title, summary, link, publish_timestamp):
+def format_message(template, title, link, publish_timestamp):
     result = template
     result = result.replace('\\n', '\n')
     result = result.replace('{title}', title)
-    result = result.replace('{summary}', summary)
     result = result.replace('{link}', link)
     result = result.replace('{publish_timestamp}', publish_timestamp)
     return result
@@ -76,7 +75,7 @@ def process_feed_response(feed):
         if epoch_publish_time <= last_processed_timestamp:
             continue
         last_processed_timestamp = epoch_publish_time
-        message = format_message(MESSAGE_TEMPLATE, entry.title, entry.summary, entry.link, entry.published)
+        message = format_message(MESSAGE_TEMPLATE, entry.title, entry.link, entry.published)
         send_message(message)
         new_messages_count = new_messages_count + 1
     set_last_processed_entry(last_processed_timestamp)

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -7,12 +7,14 @@ services:
       - "./data:/data"
     environment:
       - SIGNAL_API_URL=http://127.0.0.1:8080/v2/send
-      - SIGNAL_SENDER_NUMBER=+44xxxxxxxxxx
-      - SIGNAL_DESTINATIONS=group.xxxxxxxxxxxxx=
-      - SIGNAL_FAKE_SEND=True
-      - RSS_FEED_URL=https://xxxxxxxxxxxxx
-      - MESSAGE_TEMPLATE=NEW STOCK ALERT\n\n{title}\n\n{summary}\n\n{link}\n\n{publish_timestamp}
-      - RSS_POLL_INTERVAL=120
+      - SIGNAL_SENDER_NUMBER=+49xxxxxxxxxx
+      - SIGNAL_DESTINATIONS=group.xxxxxxxxxxxxx==,group.yyyyyyyyyyyyyy==
+#     - SIGNAL_DESTINATIONS=+49123456789
+#     - SIGNAL_DESTINATIONS=+49123456789,+491011121314
+      - SIGNAL_FAKE_SEND=False
+      - RSS_FEED_URL=https://peertube.instance/feeds/videos.xml?videoChannelId=ID
+      - MESSAGE_TEMPLATE=Check out my new video:\n\n**{title}**\n\n{link}
+      - RSS_POLL_INTERVAL=500
     logging:
       driver: "json-file"
       options:


### PR DESCRIPTION
* had to remove the `summary` field, since this is not existing in a PeerTube RSS
* added the `text_mode: styled` in the send message call, to be able to use text formatting. The [message template variable](https://github.com/francocm/rss-to-signal-bridge/compare/main...mfuhrmann:rss-to-signal-bridge:peertube?expand=1#diff-7108863dc5f2c6d8d4e8db9f04e0d64779c298b2018f1d6a6c8fc41ab476c776R16) shows an example
* added example code in the compose file